### PR TITLE
Add support for ranges

### DIFF
--- a/src/frame_search/search.py
+++ b/src/frame_search/search.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Optional, Union, TypeAlias
 
 from datetime import datetime
 from dataclasses import dataclass
@@ -7,6 +7,20 @@ import re
 import narwhals as nw
 
 Operator = Literal[":", ">", "<", ">=", "<="]
+
+Value: TypeAlias = Union[str, float, int, datetime]
+
+
+@dataclass
+class Range:
+    lower: Value
+    upper: Value
+
+    def __post_init__(self):
+        if type(self.lower) is not type(self.upper):
+            raise TypeError(
+                f"Lower and upper bounds must be of the same type: {type(self.lower)} vs {type(self.upper)}"
+            )
 
 
 def is_date_like(value: str) -> bool:
@@ -20,7 +34,7 @@ def is_date_like(value: str) -> bool:
 class SearchPart:
     key: Optional[str]
     operator: Optional[Operator]
-    value: Union[str, float, int, datetime]
+    value: Value | Range
 
     @property
     def is_standalone(self) -> bool:
@@ -38,6 +52,24 @@ def parse_query(query: str):
     #    - Group 4: standalone value
     pattern = r'(\w+):("[^"]*"|\S+)|(\S+)'
     return list(re.findall(pattern, query))
+
+
+def _parse_value(value: str) -> Value:
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+
+    if is_date_like(value):
+        # Convert to date object
+        year, month, day = map(int, value.split("-"))
+        return datetime(year, month, day)
+
+    if not isinstance(value, datetime):
+        try:
+            value = float(value) if "." in value else int(value)
+        except ValueError:
+            pass
+
+    return value
 
 
 def get_search_parts(query: str) -> list[SearchPart]:
@@ -62,21 +94,30 @@ def get_search_parts(query: str) -> list[SearchPart]:
             else:
                 operator = ":"
 
-            if value.startswith('"') and value.endswith('"'):
-                value = value[1:-1]
+            if ".." in value:
+                values = value.split("..")
+                if len(values) != 2:
+                    raise ValueError(f"Invalid range format in value: {value}")
 
-            if is_date_like(value):
-                # Convert to date object
-                year, month, day = map(int, value.split("-"))
-                value = datetime(year, month, day)
+                lower, upper = map(_parse_value, values)
+                lower = None if lower == "*" else lower
+                upper = None if upper == "*" else upper
 
-            if not isinstance(value, datetime):
-                try:
-                    value = float(value) if "." in value else int(value)
-                except ValueError:
-                    pass
+                if lower is None:
+                    operator = "<="
+                    value = upper
+                elif upper is None:
+                    operator = ">="
+                    value = lower
+                else:
+                    operator = ":"
+                    value = Range(lower=lower, upper=upper)
 
-            search_parts.append(SearchPart(key=key, operator=operator, value=value))
+                search_parts.append(SearchPart(key=key, operator=operator, value=value))
+
+            else:
+                value = _parse_value(value)
+                search_parts.append(SearchPart(key=key, operator=operator, value=value))
 
     return search_parts
 
@@ -206,6 +247,8 @@ def parse_search_query(
             expressions.append(le(col, part.value))
         elif field_dtype == nw.String or isinstance(field_dtype, str):
             expressions.append(contains(col, part.value))
+        elif isinstance(part.value, Range):
+            expressions.append(ge(col, part.value.lower) & le(col, part.value.upper))
         else:
             expressions.append(eq(col, part.value))
 

--- a/src/frame_search/search.py
+++ b/src/frame_search/search.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union, TypeAlias
+from typing import Literal, Optional, Union
 
 from datetime import datetime
 from dataclasses import dataclass
@@ -8,7 +8,7 @@ import narwhals as nw
 
 Operator = Literal[":", ">", "<", ">=", "<="]
 
-Value: TypeAlias = Union[str, float, int, datetime]
+Value = Union[str, float, int, datetime]
 
 
 @dataclass

--- a/src/frame_search/search.py
+++ b/src/frame_search/search.py
@@ -34,7 +34,7 @@ def is_date_like(value: str) -> bool:
 class SearchPart:
     key: Optional[str]
     operator: Optional[Operator]
-    value: Value | Range
+    value: Union[Value, Range]
 
     @property
     def is_standalone(self) -> bool:

--- a/src/frame_search/search.py
+++ b/src/frame_search/search.py
@@ -72,6 +72,18 @@ def _parse_value(value: str) -> Value:
     return value
 
 
+def _make_same_type(
+    first: Value,
+    second: Value,
+) -> tuple[Value, Value]:
+    """Ensure both values are of the same type."""
+
+    if isinstance(first, float) or isinstance(second, float):
+        first, second = float(first), float(second)
+
+    return first, second
+
+
 def get_search_parts(query: str) -> list[SearchPart]:
     """Parse a search query string into a list of SearchPart objects."""
     matches = parse_query(query)
@@ -111,6 +123,7 @@ def get_search_parts(query: str) -> list[SearchPart]:
                     value = lower
                 else:
                     operator = ":"
+                    lower, upper = _make_same_type(lower, upper)
                     value = Range(lower=lower, upper=upper)
 
                 search_parts.append(SearchPart(key=key, operator=operator, value=value))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -98,6 +98,7 @@ def test_get_search_parts(query, expected) -> None:
         ("age:*..35", [0, 1, 2]),
         ("age:<30", [1]),
         ("age:<=30", [0, 1]),
+        ("age:20.0..30", [0, 1]),
         ("hobby:Reading age:<30", [1]),
         ("first_visit:<2022-01-01", [1, 3]),
         ("first_visit:2022-01-01..2023-12-31", [0, 2]),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,7 +13,24 @@ from frame_search.search import (
     NoDefaultSearchColumnError,
     UnknownSearchColumnError,
     EmptySearchQueryError,
+    Range,
 )
+
+
+@pytest.mark.parametrize(
+    "lower, upper",
+    [
+        (1, 10.0),
+        (datetime(2023, 1, 1), 1),
+        (datetime(2023, 1, 1), 1.0),
+    ],
+)
+def test_range_different_type_raises(lower, upper) -> None:
+    with pytest.raises(
+        TypeError,
+        match="Lower and upper bounds must be of the same type",
+    ):
+        Range(lower, upper)
 
 
 @pytest.mark.parametrize(
@@ -75,11 +92,16 @@ def test_get_search_parts(query, expected) -> None:
         ('hobby:read city:"New York"', [0]),
         ("age:35", [2]),
         ("age:>30", [2, 3]),
+        ("age:30..35", [0, 2]),
+        ("age:30..*", [0, 2, 3]),
         ("age:>=30", [0, 2, 3]),
+        ("age:*..35", [0, 1, 2]),
         ("age:<30", [1]),
         ("age:<=30", [0, 1]),
         ("hobby:Reading age:<30", [1]),
         ("first_visit:<2022-01-01", [1, 3]),
+        ("first_visit:2022-01-01..2023-12-31", [0, 2]),
+        ("first_visit:2021-01-01..*", [0, 1, 2]),
     ],
 )
 def test_search_functionality(sample_data, search, query, idx) -> None:


### PR DESCRIPTION
This allows ranges like: 

- `age:20..30` : matches ages from 20 to 30 inclusive.
- `age:20..*` : matches ages from 20 to any value.
- `age:*..30` : matches ages from any value up to 30 inclusive.

works for dates as well: 

- `date:2020-01-01..2020-12-31` : matches dates from January 1, 2020 to December 31, 2020 inclusive.
- `date:2020-01-01..*` : matches dates from January 1, 2020 to any date.
- `date:*..2020-12-31` : matches dates from any date up
