### PR TITLE
feat: align has: and no: with GitHub search semantics

### DIFF
--- a/src/frame_search/grammar.lark
+++ b/src/frame_search/grammar.lark
@@ -21,14 +21,18 @@
 ?atom: "(" expr ")"
      | term
 
-// Terms: key:value, is:column, has:column, or standalone value
+// Terms: key:value, is:column, has:column, no:column, or standalone value
 // Order matters - more specific patterns first
 ?term: boolean_column
+     | null_check
      | key_value
      | standalone
 
-// is:column or has:column for boolean columns
-boolean_column: BOOLEAN_PREFIX COLUMN_NAME
+// is:column — column value is True (boolean column check)
+boolean_column: IS_PREFIX COLUMN_NAME
+
+// has:column — column is not null; no:column — column is null
+null_check: HAS_NO_PREFIX COLUMN_NAME
 
 // key:value - KEY_COLON includes the colon to avoid ambiguity with standalone
 key_value: KEY_COLON COMPARATOR? search_rhs
@@ -51,15 +55,15 @@ _AND: "&" | "AND"i
 _NOT: "~" | "-" | "NOT"i
 
 // Terminals - higher priority number = higher priority
-// BOOLEAN_PREFIX must come before KEY_COLON
-BOOLEAN_PREFIX.3: "is:"i | "has:"i
+IS_PREFIX.3: "is:"i
+HAS_NO_PREFIX.3: "has:"i | "no:"i
 
 // KEY_COLON captures the key AND the colon together - avoids ambiguity
 // Higher priority than STANDALONE_VALUE
-KEY_COLON.2: /(?!(?:is|has):)[a-zA-Z_][a-zA-Z0-9_]*:/ | /`[^`]+`:/
+KEY_COLON.2: /(?!(?:is|has|no):)[a-zA-Z_][a-zA-Z0-9_]*:/ | /`[^`]+`:/
 
 // STANDALONE_VALUE - lower priority, only matches when no colon follows
-STANDALONE_VALUE.1: /(?!(?:AND|OR|NOT)\b)(?!(?:is|has):)[a-zA-Z_][a-zA-Z0-9_]*/i
+STANDALONE_VALUE.1: /(?!(?:AND|OR|NOT)\b)(?!(?:is|has|no):)[a-zA-Z_][a-zA-Z0-9_]*/i
 
 BACKTICKED_KEY: /`[^`]+`/
 COLUMN_NAME: /[a-zA-Z_][a-zA-Z0-9_]*/

--- a/src/frame_search/search.py
+++ b/src/frame_search/search.py
@@ -63,19 +63,23 @@ COMPARATORS: dict[str, Callable] = {
 
 @dataclass
 class SearchNode:
-    """A search term node (key:value, is:column, or standalone value)."""
+    """A search term node (key:value, is:column, has:column, no:column, or standalone value)."""
 
     value: Value | IsIn | Range
     key: Optional[str] = None
     comparator: Optional[str] = None
     negated: bool = False
-    is_boolean_column: bool = False  # For is: and has: syntax
+    is_boolean_column: bool = False  # For is: syntax
+    is_null_check: bool = False  # For has: (not null) and no: (is null) syntax
 
     @property
     def is_standalone(self) -> bool:
         """Check if this is a standalone value without a key."""
         return (
-            self.key is None and self.comparator is None and not self.is_boolean_column
+            self.key is None
+            and self.comparator is None
+            and not self.is_boolean_column
+            and not self.is_null_check
         )
 
 
@@ -158,11 +162,21 @@ class ExprTransformer(Transformer):
         return node
 
     def boolean_column(self, prefix: Token, column: Token) -> SearchNode:
-        """Handle is:column and has:column syntax."""
+        """Handle is:column syntax — column value is True."""
         return SearchNode(
             key=column.value,
             value=True,
             is_boolean_column=True,
+        )
+
+    def null_check(self, prefix: Token, column: Token) -> SearchNode:
+        """Handle has:column (not null) and no:column (is null) syntax."""
+        is_null = prefix.value.lower().startswith("no")
+        return SearchNode(
+            key=column.value,
+            value=None,
+            is_null_check=True,
+            negated=is_null,  # negated=True means "is null" (no:), False means "not null" (has:)
         )
 
     def key_value(self, *parts) -> SearchNode:
@@ -260,6 +274,14 @@ def _build_expr(
         if search_node.negated:
             expr = ~expr
         return expr
+
+    if search_node.is_null_check:
+        assert search_node.key is not None
+        col = _resolve_column(search_node.key, mapping_to_columns, schema)
+        if search_node.negated:  # no:col — is null
+            return nw.col(col).is_null()
+        else:  # has:col — is not null
+            return ~nw.col(col).is_null()
 
     if search_node.is_standalone:
         if default is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def sample_data() -> pd.DataFrame:
                     "2020-11-05",
                 ],
             ),
+            "Nickname": ["Al", None, "Chuck", None],
         }
     ).assign(
         older_than_30=lambda df: df["Age"] > 30,
@@ -31,12 +32,34 @@ def sample_data() -> pd.DataFrame:
 
 @pytest.fixture
 def sample_data_polars(sample_data) -> pl.DataFrame:
-    return pl.from_pandas(sample_data)
+    return pl.DataFrame(
+        {
+            "Name": sample_data["Name"].tolist(),
+            "Age": sample_data["Age"].tolist(),
+            "Hobby": sample_data["Hobby"].tolist(),
+            "City of Interest": sample_data["City of Interest"].tolist(),
+            "seen_movie": sample_data["seen_movie"].tolist(),
+            "First Visit": sample_data["First Visit"].tolist(),
+            "older_than_30": sample_data["older_than_30"].tolist(),
+            "Nickname": ["Al", None, "Chuck", None],
+        }
+    )
 
 
 @pytest.fixture
 def sample_data_polars_lazy(sample_data) -> pl.LazyFrame:
-    return pl.from_pandas(sample_data).lazy()
+    return pl.DataFrame(
+        {
+            "Name": sample_data["Name"].tolist(),
+            "Age": sample_data["Age"].tolist(),
+            "Hobby": sample_data["Hobby"].tolist(),
+            "City of Interest": sample_data["City of Interest"].tolist(),
+            "seen_movie": sample_data["seen_movie"].tolist(),
+            "First Visit": sample_data["First Visit"].tolist(),
+            "older_than_30": sample_data["older_than_30"].tolist(),
+            "Nickname": ["Al", None, "Chuck", None],
+        }
+    ).lazy()
 
 
 @pytest.fixture
@@ -51,6 +74,7 @@ def search():
             "visit": "First Visit",
             "first_visit": "First Visit",
             "older_than_30": "older_than_30",
+            "nickname": "Nickname",
         },
         default="Name",
     )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -263,9 +263,9 @@ def test_negation(request, fixture_name, search, query, idx) -> None:
 @pytest.mark.parametrize(
     "query, idx",
     [
-        # is: and has: syntax
+        # is: syntax — column value is True (boolean columns)
         pytest.param("is:older_than_30", [2, 3], id="boolean-is"),
-        pytest.param("has:seen_movie", [0, 2], id="boolean-has"),
+        pytest.param("is:seen_movie", [0, 2], id="boolean-is-seen-movie"),
         # Explicit True/False values
         pytest.param("older_than_30:True", [2, 3], id="boolean-True"),
         pytest.param("older_than_30:False", [0, 1], id="boolean-False"),
@@ -279,6 +279,42 @@ def test_negation(request, fixture_name, search, query, idx) -> None:
     ],
 )
 def test_boolean_columns(request, fixture_name, search, query, idx) -> None:
+    data = request.getfixturevalue(fixture_name)
+    result = nw.from_native(data).filter(search(query)).to_native()
+
+    if isinstance(data, pl.DataFrame):
+        expected = data[idx]
+        polars.testing.assert_frame_equal(result, expected)
+    else:
+        expected = data.iloc[idx]
+        pd.testing.assert_frame_equal(result, expected)
+
+
+# =============================================================================
+# Null / Existence Tests (has: and no:)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "query, idx",
+    [
+        # has: — column is not null (rows 0 and 2 have a Nickname)
+        pytest.param("has:nickname", [0, 2], id="has-not-null"),
+        # no: — column is null (rows 1 and 3 have no Nickname)
+        pytest.param("no:nickname", [1, 3], id="no-is-null"),
+        # Combined with other terms
+        pytest.param("has:nickname name:Alice", [0], id="has-combined-with-term"),
+        pytest.param("no:nickname name:Bob", [1], id="no-combined-with-term"),
+    ],
+)
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        pytest.param("sample_data", id="pandas"),
+        pytest.param("sample_data_polars", id="polars"),
+    ],
+)
+def test_null_checks(request, fixture_name, search, query, idx) -> None:
     data = request.getfixturevalue(fixture_name)
     result = nw.from_native(data).filter(search(query)).to_native()
 


### PR DESCRIPTION
Brings `has:`, `no:`, and `is:` in line with GitHub's search interface:

- **`has:col`** — column is not null (existence check, e.g. `has:nickname`)
- **`no:col`** — column is null (absence check, e.g. `no:nickname`)
- **`is:col`** — column value is `True` (boolean check — unchanged)

Previously `has:` and `is:` were semantically identical (both checked for `True`). This change gives `has:` and `no:` the same meaning they have in GitHub search.

Closes #17