### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "frame-search"
-version = "0.3.0"
+version = "0.4.0"
 description = "Query dataframes with GitHub search syntax"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bumps version to `0.4.0` — `v0.3.0` was already released in October.